### PR TITLE
fix: add the PICASSO_ prefix condition to find packages

### DIFF
--- a/tutorpicasso/commands/enable_private_packages.py
+++ b/tutorpicasso/commands/enable_private_packages.py
@@ -118,6 +118,8 @@ def get_picasso_packages(settings: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
         and the values are package details.
     """
     picasso_packages = {
-        key: val for key, val in settings.items() if key.endswith("_DPKG") and val
+        key: val
+        for key, val in settings.items()
+        if key.startswith("PICASSO_") and key.endswith("_DPKG") and val
     }
     return picasso_packages


### PR DESCRIPTION
## Description

This PR comes from this feedback: https://3.basecamp.com/3966315/buckets/12732851/messages/7749977969#__recording_7753938708

And also, in our Readme we had that prefix condition: https://github.com/eduNEXT/tutor-contrib-picasso?tab=readme-ov-file#enable-private-packages

Also:
> It is very strongly recommended to prefix unique and default settings with the plugin name, in all-caps, such that different plugins with the same configuration do not conflict with one another.

From Tutor documentation: https://docs.tutor.edly.io/tutorials/plugin.html#modifying-configuration