### PR TITLE
fix: add patches to compile and enable themes

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -33,7 +33,9 @@ jobs:
 
       - name: Adding data to the config.yml
         run: |
+          PICASSO_TUTOR_VERSION=$(tutor --version | awk '{print $NF}')
           cat <<EOF >> config.yml
+          PICASSO_TUTOR_VERSION: $PICASSO_TUTOR_VERSION
           PICASSO_MANAGE_DPKG:
             name: eox-manage
             repo: git@github.com:eduNEXT/eox-manage.git
@@ -42,6 +44,13 @@ jobs:
             - name: endx-saas-themes
               repo: git@github.com:eduNEXT/ednx-saas-themes.git
               version: master
+          PICASSO_THEME_DIRS:
+          - /openedx/themes/ednx-saas-themes/edx-platform
+          - /openedx/themes/ednx-saas-themes/edx-platform/bragi-generator
+          - /openedx/themes/ednx-saas-themes/edx-platform/bragi-children
+          PICASSO_THEMES_NAME:
+          - bragi
+          - css-runtime
           PICASSO_EXTRA_COMMANDS:
             - tutor plugins update
             - tutor plugins index add https://raw.githubusercontent.com/eduNEXT/tutor-plugin-indexes/picasso_test/
@@ -57,6 +66,27 @@ jobs:
       - name: Check enable-themes
         run: |
           TUTOR_ROOT="$(pwd)" tutor picasso enable-themes
+
+          if grep -q 'bragi' env/build/openedx/Dockerfile; then
+            echo "'bragi' found in env/build/openedx/Dockerfile."
+          else
+            echo "'bragi' not found for the building process."
+            exit 1
+          fi
+
+          if grep -q '/openedx/themes/ednx-saas-themes/edx-platform' env/build/openedx/Dockerfile; then
+            echo "'/openedx/themes/ednx-saas-themes/edx-platform' found in env/build/openedx/Dockerfile."
+          else
+            echo "'/openedx/themes/ednx-saas-themes/edx-platform' not found for the building process."
+            exit 1
+          fi
+
+          if grep -q 'ENABLE_COMPREHENSIVE_THEMING = True' env/apps/openedx/settings/lms/production.py; then
+            echo "'ENABLE_COMPREHENSIVE_THEMING = True' found in env/apps/openedx/settings/lms/production.py."
+          else
+            echo "'ENABLE_COMPREHENSIVE_THEMING = True' not found in env/apps/openedx/settings/lms/production.py."
+            exit 1
+          fi
 
       - name: Check enable-private-packages
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Adding data to the config.yml
         run: |
-          PICASSO_TUTOR_VERSION=$(tutor --version | awk '{print $NF}')
+          TUTOR_VERSION=$(tutor --version | awk '{print $NF}')
           cat <<EOF >> config.yml
-          PICASSO_TUTOR_VERSION: $PICASSO_TUTOR_VERSION
+          TUTOR_VERSION: $TUTOR_VERSION
           PICASSO_MANAGE_DPKG:
             name: eox-manage
             repo: git@github.com:eduNEXT/eox-manage.git

--- a/README.rst
+++ b/README.rst
@@ -104,17 +104,26 @@ To enable themes in your Tutor environment, follow these steps:
 1. Add the necessary configuration in your Tutor environment's ``config.yml`` file:
 
 .. code-block:: yaml
-
+    
+    PICASSO_TUTOR_VERSION: <the version of the tutor your installation used. e.g., v18.1.1>
     PICASSO_THEMES:
-    - name: <your_theme_name>
+    - name: <your_theme_repository>
       repo: <your SSH URL for cloning the repo. e.g., git@github.com:yourorg/theme.git>
       version: <your branch, tag o release for cloning. e.g., edunext/redwood.master>
-    - name: <another_theme_name>
+    - name: <another_theme_repository>
       repo: <your SSH URL for cloning the repo. e.g., git@github.com:yourorg/another_theme.git>
       version: <your branch, tag o release for cloning. e.g., edunext/redwood.blue>
+    PICASSO_THEMES_NAME:
+    - <your theme name. e.g., bragi>
+    - <another theme name. e.g., pearson-theme>
+    PICASSO_THEME_DIRS:
+    - <the directory where you store your themes. e.g., /openedx/themes/ednx-saas-themes/edx-platform>
+    - <another directory where you store your themes. e.g., /openedx/themes/openedx-themes/edx-platform>
 
 
 **Note:** If your theme repository is public, you can also use the HTTPS URL in ``repo``.
+
+**Note:** The ``PICASSO_THEMES``, ``PICASSO_THEME_DIRS`` and ``PICASSO_THEMES_NAME`` variables are lists and can have one or more elements.
 
 2. Save the configuration with ``tutor config save``
 
@@ -125,7 +134,15 @@ To enable themes in your Tutor environment, follow these steps:
     # Enable themes
     tutor picasso enable-themes
 
-This command clones your theme repository into the folder that Tutor uses for themes. Documentation available at `Installing custom theme`_ tutorial.
+This command will clone your theme repository into the folder that Tutor uses for themes. You can find the documentation in the `Installing custom theme`_ tutorial.
+
+If ``PICASSO_THEMES`` is defined, the plugin will set ``ENABLE_COMPREHENSIVE_THEMING = True``.
+
+If ``PICASSO_THEME_DIRS`` is defined, the plugin will extend the ``COMPREHENSIVE_THEME_DIRS`` by patches.
+
+The ``PICASSO_TUTOR_VERSION``, ``PICASSO_THEME_DIRS`` and ``PICASSO_THEMES_NAME`` variables are used to compile the themes. For detailed information, see the patch `openedx-dockerfile-pre-assets <tutorpicasso/patches/openedx-dockerfile-pre-assets>`_.
+
+You can set the ``PICASSO_DEFAULT_SITE_THEME`` (optional), which will be in ``DEFAULT_SITE_THEME``; if not, we will use the first element in ``PICASSO_THEMES_NAME``.
 
 **Note:** Don't forget to add extra configurations in a Tutor plugin if your theme requires it.
 

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ To enable themes in your Tutor environment, follow these steps:
 
 .. code-block:: yaml
     
-    PICASSO_TUTOR_VERSION: <the version of the tutor your installation used. e.g., v18.1.1>
+    TUTOR_VERSION: <the version of the tutor your installation used. e.g., v18.1.1>
     PICASSO_THEMES:
     - name: <your_theme_repository>
       repo: <your SSH URL for cloning the repo. e.g., git@github.com:yourorg/theme.git>
@@ -140,7 +140,7 @@ If ``PICASSO_THEMES`` is defined, the plugin will set ``ENABLE_COMPREHENSIVE_THE
 
 If ``PICASSO_THEME_DIRS`` is defined, the plugin will extend the ``COMPREHENSIVE_THEME_DIRS`` by patches.
 
-The ``PICASSO_TUTOR_VERSION``, ``PICASSO_THEME_DIRS`` and ``PICASSO_THEMES_NAME`` variables are used to compile the themes. For detailed information, see the patch `openedx-dockerfile-pre-assets <tutorpicasso/patches/openedx-dockerfile-pre-assets>`_.
+The ``TUTOR_VERSION``, ``PICASSO_THEME_DIRS`` and ``PICASSO_THEMES_NAME`` variables are used to compile the themes. For detailed information, see the patch `openedx-dockerfile-pre-assets <tutorpicasso/patches/openedx-dockerfile-pre-assets>`_.
 
 You can set the ``PICASSO_DEFAULT_SITE_THEME`` (optional), which will be in ``DEFAULT_SITE_THEME``; if not, we will use the first element in ``PICASSO_THEMES_NAME``.
 

--- a/tutorpicasso/patches/cms-env
+++ b/tutorpicasso/patches/cms-env
@@ -1,0 +1,3 @@
+{%- if PICASSO_DEFAULT_SITE_THEME is defined or PICASSO_THEMES_NAME is defined %}
+DEFAULT_SITE_THEME: "{{ PICASSO_DEFAULT_SITE_THEME | default(PICASSO_THEMES_NAME[0]) }}"
+{% endif %}

--- a/tutorpicasso/patches/lms-env
+++ b/tutorpicasso/patches/lms-env
@@ -1,0 +1,3 @@
+{%- if PICASSO_DEFAULT_SITE_THEME is defined or PICASSO_THEMES_NAME is defined %}
+DEFAULT_SITE_THEME: "{{ PICASSO_DEFAULT_SITE_THEME | default(PICASSO_THEMES_NAME[0]) }}"
+{% endif %}

--- a/tutorpicasso/patches/openedx-cms-production-settings
+++ b/tutorpicasso/patches/openedx-cms-production-settings
@@ -1,0 +1,6 @@
+{% if PICASSO_THEMES is defined -%}
+ENABLE_COMPREHENSIVE_THEMING = True
+{%- endif %}
+{% if PICASSO_THEME_DIRS is defined -%}
+COMPREHENSIVE_THEME_DIRS.extend({{ PICASSO_THEME_DIRS }})
+{%- endif %}

--- a/tutorpicasso/patches/openedx-common-assets-settings
+++ b/tutorpicasso/patches/openedx-common-assets-settings
@@ -1,0 +1,3 @@
+{%- if PICASSO_THEME_DIRS is defined %}
+COMPREHENSIVE_THEME_DIRS.extend({{ PICASSO_THEME_DIRS }})
+{%- endif %}

--- a/tutorpicasso/patches/openedx-development-settings
+++ b/tutorpicasso/patches/openedx-development-settings
@@ -1,0 +1,6 @@
+{% if PICASSO_THEMES is defined -%}
+ENABLE_COMPREHENSIVE_THEMING = True
+{%- endif %}
+{%- if PICASSO_THEME_DIRS is defined %}
+COMPREHENSIVE_THEME_DIRS.extend({{ PICASSO_THEME_DIRS }})
+{%- endif %}

--- a/tutorpicasso/patches/openedx-dockerfile-pre-assets
+++ b/tutorpicasso/patches/openedx-dockerfile-pre-assets
@@ -1,6 +1,6 @@
-{% if PICASSO_TUTOR_VERSION is defined and PICASSO_THEME_DIRS is defined and PICASSO_THEMES_NAME is defined %}
+{% if TUTOR_VERSION is defined and PICASSO_THEME_DIRS is defined and PICASSO_THEMES_NAME is defined %}
 {% set redwood_version = 'v18.0.0'.lstrip('v').split('.') %}
-{% set current_version = PICASSO_TUTOR_VERSION.lstrip('v').split('.') %}
+{% set current_version = TUTOR_VERSION.lstrip('v').split('.') %}
 {% set redwood_version = redwood_version | map('int') | list %}
 {% set current_version = current_version | map('int') | list %}
 

--- a/tutorpicasso/patches/openedx-dockerfile-pre-assets
+++ b/tutorpicasso/patches/openedx-dockerfile-pre-assets
@@ -7,6 +7,16 @@
 COPY --chown=app:app ./themes/ /openedx/themes
 {% if (current_version[0] < redwood_version[0]) %}
 # This compiles the Picasso themes assets in the releases < redwood.
+
+# These commands are already in the Dockerfile Tutor template,
+# but we needed them for the Picasso themes compilation.
+ENV NO_PYTHON_UNINSTALL 1
+ENV NO_PREREQ_INSTALL 1
+RUN openedx-assets xmodule \
+    && openedx-assets npm \
+    && openedx-assets webpack --env=prod \
+    && openedx-assets common
+# Compiling the Picasso themes.
 RUN openedx-assets themes \
     --theme-dirs {{ PICASSO_THEME_DIRS | join(' ') }} \
     --themes {{ PICASSO_THEMES_NAME | join(' ') }} \
@@ -14,6 +24,13 @@ RUN openedx-assets themes \
     && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/
 {% else %}
 # This compiles the Picasso themes assets from the redwood release.
+
+# These commands are already in the Dockerfile Tutor template,
+# but we needed them for the Picasso themes compilation.
+RUN npm run postinstall
+RUN npm run compile-sass -- --skip-themes
+RUN npm run webpack
+# Compiling the Picasso themes.
 RUN npm run compile-sass -- \
     --theme-dir {{ PICASSO_THEME_DIRS | join(' --theme-dir ') }} \
     --theme {{ PICASSO_THEMES_NAME | join(' --theme ') }} \

--- a/tutorpicasso/patches/openedx-dockerfile-pre-assets
+++ b/tutorpicasso/patches/openedx-dockerfile-pre-assets
@@ -1,0 +1,23 @@
+{% if PICASSO_TUTOR_VERSION is defined and PICASSO_THEME_DIRS is defined and PICASSO_THEMES_NAME is defined %}
+{% set redwood_version = 'v18.0.0'.lstrip('v').split('.') %}
+{% set current_version = PICASSO_TUTOR_VERSION.lstrip('v').split('.') %}
+{% set redwood_version = redwood_version | map('int') | list %}
+{% set current_version = current_version | map('int') | list %}
+
+COPY --chown=app:app ./themes/ /openedx/themes
+{% if (current_version[0] < redwood_version[0]) %}
+# This compiles the Picasso themes assets in the releases < redwood.
+RUN openedx-assets themes \
+    --theme-dirs {{ PICASSO_THEME_DIRS | join(' ') }} \
+    --themes {{ PICASSO_THEMES_NAME | join(' ') }} \
+    && openedx-assets collect --settings=tutor.assets \
+    && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/
+{% else %}
+# This compiles the Picasso themes assets from the redwood release.
+RUN npm run compile-sass -- \
+    --theme-dir {{ PICASSO_THEME_DIRS | join(' --theme-dir ') }} \
+    --theme {{ PICASSO_THEMES_NAME | join(' --theme ') }} \
+    && ./manage.py lms collectstatic --noinput --settings=tutor.assets \
+    && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/
+{% endif %}
+{% endif %}

--- a/tutorpicasso/patches/openedx-lms-production-settings
+++ b/tutorpicasso/patches/openedx-lms-production-settings
@@ -1,0 +1,6 @@
+{% if PICASSO_THEMES is defined -%}
+ENABLE_COMPREHENSIVE_THEMING = True
+{%- endif %}
+{% if PICASSO_THEME_DIRS is defined -%}
+COMPREHENSIVE_THEME_DIRS.extend({{ PICASSO_THEME_DIRS }})
+{%- endif %}


### PR DESCRIPTION
## Description

This PR adds the necessary patches to compile and enable the themes.

For adding the patches we read: ``PICASSO_TUTOR_VERSION``, ``PICASSO_THEME_DIRS`` and ``PICASSO_THEMES_NAME``, similar to `tutor-contrib-edunext-distro`.

## Context

With the command `enable-themes`, we are cloning our repository themes in `/openedx/themes`, but the themes sometimes aren't in the root of that repository, and we need to specify the platform where to find our themes. So, we use ``PICASSO_THEME_DIRS``. We also need to compile the themes and enable the comprehensive themes.

## How to test it

This code is used in this job: https://picasso.dedalo.edunext.co/job/PicassoV2_and_picasso_tutor_plugin/

I have already tried it with the following:
- Redwood: https://github.com/eduNEXT/ednx-strains/blob/mfmz/redwood-tutor-contrib-picasso/redwood/base/config.yml
    - https://picasso.dedalo.edunext.co/job/PicassoV2_and_picasso_tutor_plugin/20
- Olive: https://github.com/eduNEXT/ednx-strains/blob/mfmz/tutor-contrib-picasso/olmo/dedalo/mfe_runtime/config.yml
    - https://picasso.dedalo.edunext.co/job/PicassoV2_and_picasso_tutor_plugin/21

## Extra

Consequence: I propose changing TUTOR_VERSION to ``PICASSO_TUTOR_VERSION`` because we will need something to have different versions of the compile.