### PR TITLE
Fix validate version when we are using tutor main

### DIFF
--- a/tutorpicasso/commands/enable_private_packages.py
+++ b/tutorpicasso/commands/enable_private_packages.py
@@ -5,9 +5,9 @@ from typing import Any, Dict
 import click
 from packaging.version import Version
 from tutor import config as tutor_config
-from tutor.__about__ import __version__ as tutor_version
-from tutor import utils as tutor_utils
 from tutor import fmt as tutor_fmt
+from tutor import utils as tutor_utils
+from tutor.__about__ import __version__ as tutor_version
 
 
 @click.command(name="enable-private-packages", help="Enable picasso private packages")

--- a/tutorpicasso/commands/run_extra_commands.py
+++ b/tutorpicasso/commands/run_extra_commands.py
@@ -1,7 +1,6 @@
 import re
 import subprocess
 from itertools import chain
-
 from typing import Any, List, Pattern
 
 import click

--- a/tutorpicasso/plugin.py
+++ b/tutorpicasso/plugin.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import os
+import re
 from glob import glob
 
 import click
 import importlib_resources
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 from tutor import hooks
 from tutor.__about__ import __version__ as tutor_version
 
@@ -19,8 +20,6 @@ from .__about__ import __version__
 
 # Tutor introduces the MOUNTED_DIRECTORIES in the latest Palm version.
 latest_palm_version = "16.1.8"
-import re
-from packaging.version import Version, InvalidVersion
 
 
 def safe_version(v: str) -> Version:

--- a/tutorpicasso/plugin.py
+++ b/tutorpicasso/plugin.py
@@ -19,7 +19,32 @@ from .__about__ import __version__
 
 # Tutor introduces the MOUNTED_DIRECTORIES in the latest Palm version.
 latest_palm_version = "16.1.8"
-if Version(tutor_version) > Version(latest_palm_version):
+import re
+from packaging.version import Version, InvalidVersion
+
+
+def safe_version(v: str) -> Version:
+    """Parse a version string, tolerating non-PEP-440 suffixes like '-main', '-dev', etc.
+
+    Converts '21.0.6-main' -> '21.0.6+main' (a valid PEP 440 local version),
+    and falls back to stripping the suffix entirely if that still fails.
+    """
+    try:
+        return Version(v)
+    except InvalidVersion:
+        pass
+
+    # Replace the first '-<suffix>' with '+<suffix>' (PEP 440 local segment)
+    normalized = re.sub(r"-([A-Za-z][\w.]*)", r"+\1", v, count=1)
+    try:
+        return Version(normalized)
+    except InvalidVersion:
+        # Last resort: strip any trailing non-numeric segment
+        stripped = re.sub(r"[-+].*$", "", v)
+        return Version(stripped)
+
+
+if safe_version(tutor_version) > safe_version(latest_palm_version):
     hooks.Filters.MOUNTED_DIRECTORIES.add_items(
         [
             ("openedx", r"eox-.*"),


### PR DESCRIPTION
### Description

These changes fix a build error in the Open edX image.

When generating the Tutor version for the `main` branch, the version string is constructed by appending `-main` to the latest release tag (e.g., `21.0.6-main`). However, `tutor-contrib-picasso` performs a semantic version validation, and the hyphen causes this check to fail, breaking the build.

This PR addresses the issue by ensuring the version string is handled in a way that passes the semantic versioning validation.