### PR TITLE
chore: add compatibility for tutor main

### DIFF
--- a/tutorpicasso/commands/enable_private_packages.py
+++ b/tutorpicasso/commands/enable_private_packages.py
@@ -58,10 +58,9 @@ def handle_private_requirements_by_tutor_version(
         info (Dict[str, str]): A dictionary containing metadata about the requirement. Expected to have a "name" key.
         private_requirements_path (str): The directory path to store the private requirements.
     """
-    tutor_version_obj = Version(tutor_version)
-    quince_version_obj = Version("v17.0.0")
+    quince_version = "v17.0.0"
 
-    if tutor_version_obj < quince_version_obj:
+    if "main" not in tutor_version and Version(tutor_version) < Version(quince_version):
         private_txt_path = f"{private_requirements_path}/private.txt"
         _enable_private_requirements_before_quince(info, private_txt_path)
     else:

--- a/tutorpicasso/plugin.py
+++ b/tutorpicasso/plugin.py
@@ -19,7 +19,7 @@ from .__about__ import __version__
 
 # Tutor introduces the MOUNTED_DIRECTORIES in the latest Palm version.
 latest_palm_version = "16.1.8"
-if Version(tutor_version) > Version(latest_palm_version):
+if "main" in tutor_version or Version(tutor_version) > Version(latest_palm_version):
     hooks.Filters.MOUNTED_DIRECTORIES.add_items(
         [
             ("openedx", r"eox-.*"),


### PR DESCRIPTION
## Description

This PR fixes issue where build with tutor main fails with:

```
packaging.version.InvalidVersion: Invalid version: '21.0.8-main'
```

This is because tutor [adds](https://github.com/overhangio/tutor/blob/d35b2f1783962769b25fefef39f50335da7fbfb0/tutor/__about__.py#L13-L28) the suffix `main` is added to the version number

## Testing instructions

Trigger a build with Picasso/Harmony with `TUTOR_VERSION` set to `main`


## Other information

Private Ref : [SE-6648](https://tasks.opencraft.com/browse/SE-6648)